### PR TITLE
Filters hash

### DIFF
--- a/maediprojects/static/js/activities.js
+++ b/maediprojects/static/js/activities.js
@@ -68,12 +68,16 @@ var queryProjectsData = function() {
         "id": "latest_date", "value": selected_latest_activity_date.toJSON()
       })
   };
+
+  var filtersApplied = false;
   $(fv_data).each(function(i, f) {
     data[f["id"]] = f["value"]
     if (i == 0) { query+= "?" 
     } else { query+= "&" }
+    if (f["value"] != "all") { filtersApplied=true; }
     query += f["id"] + "=" + f["value"];
   });
+  makeFiltersApplied(filtersApplied);
   $("#activities_count").text("loading...");
   $("#projectsList").html('<p class="lead">Loading data, please wait... <span class="glyphicon glyphicon-refresh loader" aria-hidden="true"></span></p>');
 
@@ -81,6 +85,7 @@ var queryProjectsData = function() {
     updateProjects(resultdata);
   });
   $("#download_excel").attr("href", "/api/activities_filtered.xlsx" + query);
+  window.location.hash = query;
 }
 $(document).on("change", ".filter-select", function(e) {
   queryProjectsData();
@@ -93,6 +98,36 @@ $(document).on("slideStop", "#date-selector", function(e) {
   $(".date-select .min-date").text(min_date.getFullYear());
   $(".date-select .max-date").text(max_date.getFullYear());
 });
-// Initial load
-$(".filter-select").val("all");
+
+function makeFiltersApplied(applied) {
+  if (applied == true) {
+    $("#filtersAppliedLabel").html('<span class="label label-danger"><a href="">Reset filters</a></span>'
+      ).delay("500").fadeTo("fast", 1).fadeTo("100", 0.2).fadeTo("fast", 1);
+  } else {
+    $("#filtersAppliedLabel").fadeOut("fast").next().html("");
+  }
+}
+$(document).on("click", "#filtersAppliedLabel a", function(e) {
+  e.preventDefault();
+  $(".filter-select").val("all");
+  makeFiltersApplied(false);
+  queryProjectsData();
+});
+// Make results persistent using URL hash
+var url = document.location.toString();
+if (url.match('#')) {
+    params = url.split("#?")[1].split("&");
+    console.log(params);
+    var filtersApplied=false;
+    params.forEach(function(param) {
+      var key = param.split("=")[0];
+      var value = param.split("=")[1];
+      $(".form-activity-filters #"+key).val(value);
+      if (value != "all") {
+        filtersApplied=true;
+      }
+    });
+    makeFiltersApplied(filtersApplied);
+    window.scrollTo(0, 0);
+}
 queryProjectsData()

--- a/maediprojects/static/js/activity_edit.js
+++ b/maediprojects/static/js/activity_edit.js
@@ -493,3 +493,18 @@ $(document).on("change", "#milestones input[type=checkbox], #milestones textarea
     errorFormGroup(input);
   });
 });
+
+// Javascript to enable link to tab
+var url = document.location.toString();
+if (url.match('#')) {
+    if (url.split('#')[1] == "location") {
+      setupLocations();
+    }
+    $('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
+    window.scrollTo(0, 0);
+}
+// Change hash for page-reload
+$('.nav-tabs a').on('shown.bs.tab', function (e) {
+    window.location.hash = e.target.hash;
+    window.scrollTo(0, 0);
+})

--- a/maediprojects/templates/activities.html
+++ b/maediprojects/templates/activities.html
@@ -24,8 +24,8 @@
         <div class="panel-heading" role="tab" id="headingOne">
           <h4 class="panel-title">
             <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-              Show filters
-            </a>
+              Show filters</a>
+              <span id="filtersAppliedLabel"></span>
           </h4>
         </div>
         <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">


### PR DESCRIPTION
Adds filters to hash on /activities to make filters persistent when clicking forward/back.

Adds hash to activity editor so that editor switches to relevant tab (e.g. #locations, #finances, etc.)

Fixes #6