### PR TITLE
Show MTEF projections by fiscal year on activity editor

### DIFF
--- a/maediprojects/templates/activity_edit.html
+++ b/maediprojects/templates/activity_edit.html
@@ -474,10 +474,9 @@
   <table class="table">
     <thead>
       <th>{% endraw %}{{ _('Year') }}{% raw %}</th>
-      <th>{% endraw %}{{ _('Jan-Mar') }}{% raw %}</th>
-      <th>{% endraw %}{{ _('Apr-Jun') }}{% raw %}</th>
-      <th>{% endraw %}{{ _('Jul-Sep') }}{% raw %}</th>
-      <th>{% endraw %}{{ _('Oct-Dec') }}{% raw %}</th>
+      {{# quarters }}
+      <th>{{ quarter_name }} ({{ quarter_months }})</th>
+      {{/ quarters }}
       <!--<th>{% endraw %}{{ _('Total') }}{% raw %}</th>-->
     </thead>
     <tbody id="forward-spend-rows">


### PR DESCRIPTION
On the activity editor, shows MTEF projections by fiscal year, rather than by calendar year.

Maybe hold on merging this for now because the code could be a lot tidier here and less repetitive.

Fixes #1 