### PR TITLE
Forward projections templates

### DIFF
--- a/maediprojects/lib/util.py
+++ b/maediprojects/lib/util.py
@@ -1,6 +1,6 @@
 import datetime, re
 
-ALLOWED_YEARS = range(2013, 2019)
+ALLOWED_YEARS = range(2013, datetime.datetime.utcnow().year+3)
 
 MONTHS_QUARTERS = {
     1: 1, 2: 1, 3: 1, 4: 2, 5: 2, 6: 2, 7: 3, 8: 3, 9: 3, 10: 4, 
@@ -42,6 +42,21 @@ LR_PERIODS_MONTH_DAY = {
     "M5": {"start": (1, 11), "end": (30, 11)},
     "M6": {"start": (1, 12), "end": (31, 12)}
 }
+
+LR_QUARTERS_CAL_QUARTERS = {
+    1: 3,
+    2: 4,
+    3: 1,
+    4: 2
+}
+
+def lr_quarter_to_cal_quarter(_fy, _fq):
+    if _fq in (3,4):
+        year = _fy+1
+    else:
+        year = _fy
+    quarter = LR_QUARTERS_CAL_QUARTERS[_fq]
+    return year, quarter
 
 def fp_fy_to_date(fp, fy, start_end='start'):
     """Convert from LR FP, FY to real date."""

--- a/maediprojects/models.py
+++ b/maediprojects/models.py
@@ -29,7 +29,7 @@ FWDDATA_QUERY = u"""
     END AS fiscal_quarter
     FROM forwardspend
     WHERE forwardspend.activity_id = '%s'
-    AND value > 0
+    AND value != 0
     GROUP BY fiscal_quarter, fiscal_year
     ORDER BY forwardspend.period_start_date DESC
     """
@@ -47,7 +47,7 @@ FYDATA_QUERY = u"""
     FROM activityfinances
     WHERE activityfinances.activity_id = '%s'
     AND activityfinances.transaction_type IN (%s)
-    AND transaction_value > 0
+    AND transaction_value != 0
     GROUP BY fiscal_quarter, fiscal_year
     ORDER BY activityfinances.transaction_date DESC
     """
@@ -338,6 +338,8 @@ class ActivityForwardSpend(db.Model):
     value_currency = sa.Column(sa.UnicodeText)
     period_start_date = sa.Column(sa.Date)
     period_end_date = sa.Column(sa.Date)
+
+    __table_args__ = (sa.UniqueConstraint('activity_id','period_start_date'),)
 
     def as_dict(self):
        return {c.name: getattr(self, c.name) for c in self.__table__.columns}

--- a/maediprojects/query/finances.py
+++ b/maediprojects/query/finances.py
@@ -161,6 +161,31 @@ def create_missing_forward_spends(from_date, to_date, activity_id):
     forward_spends = create_forward_spends_from_periods(new_periods)
     return forward_spends
 
+def create_or_update_forwardspend(activity_id, quarter, year, value, currency):
+    # NB quarters are in calendar quarters, not Liberian fiscal quarters
+    start_day, start_month = QUARTERS_MONTH_DAY[quarter]["start"]
+    end_day, end_month = QUARTERS_MONTH_DAY[quarter]["end"]
+    start_date = datetime.datetime(year, start_month, start_day).date()
+    end_date = datetime.datetime(year, end_month, end_day).date()
+    fs = models.ActivityForwardSpend.query.filter_by(activity_id=activity_id,
+        period_start_date=start_date).first()
+    if fs:
+        fs.value = value
+        db.session.add(fs)
+        db.session.commit()
+        return fs
+    else:
+        fs = models.ActivityForwardSpend()
+        fs.activity_id = activity_id
+        fs.value = value
+        fs.value_date = start_date
+        fs.value_currency = currency
+        fs.period_start_date = start_date
+        fs.period_end_date = end_date
+        db.session.add(fs)
+        db.session.commit()
+        return fs
+
 def create_forward_spend(quarter, year, value, currency):
     # NB quarters are in calendar quarters, not Liberian fiscal quarters
     fs = models.ActivityForwardSpend()

--- a/maediprojects/query/generate_csv.py
+++ b/maediprojects/query/generate_csv.py
@@ -77,16 +77,21 @@ def activity_to_json(activity, cl_lookups):
     data.update(dict(map(lambda d: (d[0], d[1]["value"]), activity.FY_disbursements_dict.items())))
     # Add MTEF data
     data.update(dict(map(lambda d: (d[0], d[1]["value"]), activity.FY_forward_spend_dict.items())))
+
+    data.update(dict(map(lambda d: (d, 0.00), list(filter(lambda h: h not in data, generate_disb_fys())))))
     return data
 
 def generate_disb_fys():
-    #FIXME don't hard code start/end years
+    #FIXME don't hard code start year
     disbFYs_QTRs = [("{} Q1 (MTEF)".format(fy), "{} Q2 (MTEF)".format(fy), 
                      "{} Q3 (MTEF)".format(fy), "{} Q4 (MTEF)".format(fy),
-                     "{} Q1 (D)".format(fy), "{} Q2 (D)".format(fy), 
+                     "{} Q1 (D)".format(fy), "{} Q2 (D)".format(fy),
                      "{} Q3 (D)".format(fy), "{} Q4 (D)".format(fy)
-                     ) for fy in range(2013, 2019)]
-    return [item for sublist in disbFYs_QTRs for item in sublist]
+                     ) for fy in range(2013, datetime.datetime.utcnow().year+1)]
+    MTEFFYs_QTRs = [("{} Q1 (MTEF)".format(fy), "{} Q2 (MTEF)".format(fy), 
+                     "{} Q3 (MTEF)".format(fy), "{} Q4 (MTEF)".format(fy)
+                     ) for fy in range(datetime.datetime.utcnow().year+1, datetime.datetime.utcnow().year+4)]
+    return [item for sublist in disbFYs_QTRs for item in sublist]+[item for sublist in MTEFFYs_QTRs for item in sublist]
 
 def generate_csv():
     csv_file = StringIO.StringIO()

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -239,7 +239,7 @@ def import_xls(input_file, column_name=u"2018 Q1 (D)"):
                 input_file.filename, input_file.read(), sheet_id, True)
             for row in data: # each row is one ID
                 if column_name not in row:
-                    flash("The column {} containing financial data was not \
+                    flash(u"The column {} containing financial data was not \
                     found in the uploaded spreadsheet!".format(column_name), "danger")
                     raise Exception
                 if ((row[column_name] == "") or 
@@ -249,7 +249,7 @@ def import_xls(input_file, column_name=u"2018 Q1 (D)"):
                 activity_id = row[u"ID"]
                 activity = qactivity.get_activity(activity_id)
                 if not activity:
-                    flash("Warning, activity ID \"{}\" with title \"{}\" was not found in the system \
+                    flash(u"Warning, activity ID \"{}\" with title \"{}\" was not found in the system \
                         and was not imported! Please create this activity in the \
                         system before trying to import.".format(row[u'ID'], row[u'Activity Title']), "warning")
                     continue
@@ -265,9 +265,10 @@ def import_xls(input_file, column_name=u"2018 Q1 (D)"):
                 )
                 db.session.add(activity)
                 num_updated_activities += 1
+                qactivity.activity_updated(activity.id)
 
                 if existing_activity.get(column_name):
-                    flash("Updated {} for {} (Project ID: {}); previous value was {}; \
+                    flash(u"Updated {} for {} (Project ID: {}); previous value was {}; \
                         new value is {}. New entry for {} added.".format(
                     util.column_data_to_string(column_name),
                     activity.title, activity.id,
@@ -276,16 +277,16 @@ def import_xls(input_file, column_name=u"2018 Q1 (D)"):
                     difference
                     ), "success")
                 else:
-                    flash("Updated {} for {} (Project ID: {})".format(
+                    flash(u"Updated {} for {} (Project ID: {})".format(
                     util.column_data_to_string(column_name),
                     activity.title, activity.id), "success")
     except Exception, e:
         if activity_id:
-            flash("""There was an unexpected error when importing your
+            flash(u"""There was an unexpected error when importing your
             projects, there appears to be an error around activity ID {}. 
             The error was: {}""".format(activity_id, e), "danger")
         else:
-            flash("""There was an unexpected error when importing your projects, 
+            flash(u"""There was an unexpected error when importing your projects, 
         the error was: {}""".format(e), "danger")
     db.session.commit()
     return num_updated_activities

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -79,7 +79,7 @@ class xlsxDictWriter(object):
 def tidy_amount(amount_value):
     amount_value = amount_value.strip()
     amount_value = re.sub(",", "", amount_value)
-    if re.match(r'-?(\d*\.?\d*)', amount_value):  # 2000 or -2000
+    if re.match(r'-?\d*\.?\d*', amount_value):  # 2000 or -2000
         return (float(amount_value), u"USD")
     elif re.match(r"^(\d*)m (\D*)$", amount_value):  # 20m EUR
         result = re.match(r"^(\d*)m (\D*)$", amount_value).groups()

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -79,13 +79,13 @@ class xlsxDictWriter(object):
 def tidy_amount(amount_value):
     amount_value = amount_value.strip()
     amount_value = re.sub(",", "", amount_value)
-    if re.match('-?(\d*\.?\d*)', amount_value): # 2000 or -2000
+    if re.match(r'-?(\d*\.?\d*)', amount_value):  # 2000 or -2000
         return (float(amount_value), u"USD")
-    elif re.match("^(\d*)m (\D*)$", amount_value): # 20m EUR
-        result = re.match("^(\d*)m (\D*)$", amount_value).groups()
+    elif re.match(r"^(\d*)m (\D*)$", amount_value):  # 20m EUR
+        result = re.match(r"^(\d*)m (\D*)$", amount_value).groups()
         return (float(result[0])*1000000, unicode(result[1].upper()))
-    elif re.match("^(\d*) (\D*)$", amount_value): # 2000 EUR
-        result = re.match("^(\d*) (\D*)$", amount_value).groups()
+    elif re.match(r"^(\d*) (\D*)$", amount_value):  # 2000 EUR
+        result = re.match(r"^(\d*) (\D*)$", amount_value).groups()
         return (float(result[0]), unicode(result[1].upper()))
 
 def process_transaction_classifications(activity):

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -79,9 +79,7 @@ class xlsxDictWriter(object):
 def tidy_amount(amount_value):
     amount_value = amount_value.strip()
     amount_value = re.sub(",", "", amount_value)
-    if re.match("^-?(\d*)$", amount_value): # 2000 or -2000
-        return (float(amount_value), u"USD")
-    elif re.match('-?(\d*\.\d*)', amount_value):
+    if re.match('-?(\d*\.?\d*)', amount_value): # 2000 or -2000
         return (float(amount_value), u"USD")
     elif re.match("^(\d*)m (\D*)$", amount_value): # 20m EUR
         result = re.match("^(\d*)m (\D*)$", amount_value).groups()

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -79,9 +79,9 @@ class xlsxDictWriter(object):
 def tidy_amount(amount_value):
     amount_value = amount_value.strip()
     amount_value = re.sub(",", "", amount_value)
-    if re.match("^\d*$", amount_value): # 2000
+    if re.match("^-?(\d*)$", amount_value): # 2000 or -2000
         return (float(amount_value), u"USD")
-    elif re.match('(\d*\.\d*)', amount_value):
+    elif re.match('-?(\d*\.\d*)', amount_value):
         return (float(amount_value), u"USD")
     elif re.match("^(\d*)m (\D*)$", amount_value): # 20m EUR
         result = re.match("^(\d*)m (\D*)$", amount_value).groups()

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -79,7 +79,7 @@ class xlsxDictWriter(object):
 def tidy_amount(amount_value):
     amount_value = amount_value.strip()
     amount_value = re.sub(",", "", amount_value)
-    if re.match(r'-?\d*\.?\d*', amount_value):  # 2000 or -2000
+    if re.match(r'^-?\d*\.?\d*$', amount_value):  # 2000 or -2000
         return (float(amount_value), u"USD")
     elif re.match(r"^(\d*)m (\D*)$", amount_value):  # 20m EUR
         result = re.match(r"^(\d*)m (\D*)$", amount_value).groups()

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -332,6 +332,7 @@ def generate_xlsx_export_template(data, mtef=False):
         _headers += [u'Activity Status', u'Activity Dates (Start Date)', u'Activity Dates (End Date)',
     u"County"]
     else:
+        mtef_cols = []
         _headers = [u"ID", u"Project code", u"Activity Title", util.previous_fy_fq(),
     u'Activity Status', u'Activity Dates (Start Date)', u'Activity Dates (End Date)',
     u"County",]

--- a/maediprojects/query/generate_xlsx.py
+++ b/maediprojects/query/generate_xlsx.py
@@ -234,8 +234,14 @@ def generate_xlsx_filtered(arguments):
     writer.delete_first_sheet()
     return writer.save()
 
-def generate_xlsx_export_template(data):
-    _headers = [u"ID", u"Project code", u"Activity Title", util.previous_fy_fq(),
+def generate_xlsx_export_template(data, mtef=False):
+    if mtef:
+        _headers = [u"ID", u"Project code", u"Activity Title",
+        u"FY19/20 (MTEF)", u"FY20/21 (MTEF)", u"FY21/22 (MTEF)",
+    u'Activity Status', u'Activity Dates (Start Date)', u'Activity Dates (End Date)',
+    u"County",]
+    else:
+        _headers = [u"ID", u"Project code", u"Activity Title", util.previous_fy_fq(),
     u'Activity Status', u'Activity Dates (Start Date)', u'Activity Dates (End Date)',
     u"County",]
     writer = xlsxDictWriter(_headers)
@@ -277,19 +283,38 @@ def generate_xlsx_export_template(data):
         #writer.ws.protection.sheet = True
         for activity in activities:
             writer.writerow(activity_to_json(activity, cl_lookups))
-        writer.ws.column_dimensions[u"C"].width = 70
-        writer.ws.column_dimensions[u"D"].width = 15
-        writer.ws.column_dimensions[u"E"].width = 15
-        writer.ws.column_dimensions[u"F"].width = 20
-        writer.ws.column_dimensions[u"G"].width = 15
-        for rownum in range(1+1, len(activities)+2):
-            writer.ws.cell(row=rownum,column=4).fill = myFill
-            writer.ws.cell(row=rownum,column=4).number_format = u'"USD "#,##0.00'
-            #writer.ws.cell(row=rownum,column=4).protection = Protection(locked=False)
-        v_id.add('A2:A{}'.format(len(activities)+2))
-        v_number.add('D2:D{}'.format(len(activities)+2))
-        v_status.add('E2:E{}'.format(len(activities)+2))
-        v_date.add('F2:G{}'.format(len(activities)+2))
+        if mtef == True:
+            for rownum in range(1+1, len(activities)+2):
+                writer.ws.cell(row=rownum,column=4).fill = myFill
+                writer.ws.cell(row=rownum,column=5).fill = myFill
+                writer.ws.cell(row=rownum,column=6).fill = myFill
+                writer.ws.cell(row=rownum,column=4).number_format = u'"USD "#,##0.00'
+                writer.ws.cell(row=rownum,column=5).number_format = u'"USD "#,##0.00'
+                writer.ws.cell(row=rownum,column=6).number_format = u'"USD "#,##0.00'
+            writer.ws.column_dimensions[u"C"].width = 70
+            writer.ws.column_dimensions[u"D"].width = 15
+            writer.ws.column_dimensions[u"E"].width = 15
+            writer.ws.column_dimensions[u"F"].width = 15
+            writer.ws.column_dimensions[u"G"].width = 15
+            writer.ws.column_dimensions[u"H"].width = 20
+            writer.ws.column_dimensions[u"I"].width = 20
+            v_id.add('A2:A{}'.format(len(activities)+2))
+            v_number.add('D2:F{}'.format(len(activities)+2))
+            v_status.add('G2:G{}'.format(len(activities)+2))
+            v_date.add('H2:I{}'.format(len(activities)+2))
+        elif mtef == False:
+            for rownum in range(1+1, len(activities)+2):
+                writer.ws.cell(row=rownum,column=4).fill = myFill
+                writer.ws.cell(row=rownum,column=4).number_format = u'"USD "#,##0.00'
+            writer.ws.column_dimensions[u"C"].width = 70
+            writer.ws.column_dimensions[u"D"].width = 15
+            writer.ws.column_dimensions[u"E"].width = 15
+            writer.ws.column_dimensions[u"F"].width = 20
+            writer.ws.column_dimensions[u"G"].width = 15
+            v_id.add('A2:A{}'.format(len(activities)+2))
+            v_number.add('D2:D{}'.format(len(activities)+2))
+            v_status.add('E2:E{}'.format(len(activities)+2))
+            v_date.add('F2:G{}'.format(len(activities)+2))
     writer.delete_first_sheet()
     return writer.save()
 

--- a/maediprojects/static/js/activity_edit.js
+++ b/maediprojects/static/js/activity_edit.js
@@ -278,7 +278,9 @@ $( '.set-column-visibility li' ).on( 'click', function( event ) {
     }
     /*$("."+_target).toggle();*/
     return false;
-}); 
+});
+
+/*  Financials */
 $(document).on("click", ".addFinancial", function(e) {
   e.preventDefault();
   var transaction_type = $(this).attr("data-transaction-type");
@@ -402,7 +404,7 @@ var setupFinances = function() {
 };
 setupFinances()
 
-$(document).on("change", "#finances input[type=text], #finances select", function(e) {
+$(document).on("change", ".finances-data input[type=text], #finances select", function(e) {
   var data = {
     'finances_id': $(this).closest("tr").attr("data-financial-id"),
     'attr': this.name,
@@ -431,7 +433,7 @@ var setupForwardSpend = function() {
 };
 setupForwardSpend()
 
-$(document).on("change", "#financial-data-FS input[type=text]", function(e) {
+$(document).on("change", ".forwardspends-data input[type=text]", function(e) {
   if ($(this).attr("data-forwardspend-id")) {
     var data = {
       'id': $(this).attr("data-forwardspend-id"),

--- a/maediprojects/templates/activity_edit.html
+++ b/maediprojects/templates/activity_edit.html
@@ -600,14 +600,14 @@
       </div>
       <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <div class="panel panel-default">
-          <div class="panel-heading" role="tab" id="headingOne">
+          <div class="panel-heading" role="tab" id="headingCommitments">
             <h4 class="panel-title">
-              <a role="button" data-toggle="collapse" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+              <a role="button" data-toggle="collapse" href="#collapseCommitments" aria-expanded="true" aria-controls="collapseCommitments">
                 {{ _('Commitments') }}
               </a>
             </h4>
           </div>
-          <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+          <div id="collapseCommitments" class="panel-collapse collapse in finances-data" role="tabpanel" aria-labelledby="headingCommitments">
             <div class="panel-body">
               <div class="row">
                 <div class="col-sm-12">
@@ -627,14 +627,14 @@
           </div>
         </div>
         <div class="panel panel-default">
-          <div class="panel-heading" role="tab" id="headingTwo">
+          <div class="panel-heading" role="tab" id="headingDisbursements">
             <h4 class="panel-title">
-              <a class="collapsed" role="button" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+              <a class="collapsed" role="button" data-toggle="collapse" href="#collapseDisbursements" aria-expanded="false" aria-controls="collapseDisbursements">
                 {{ _('Disbursements') }}
               </a>
             </h4>
           </div>
-          <div id="collapseTwo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
+          <div id="collapseDisbursements" class="panel-collapse collapse in finances-data" role="tabpanel" aria-labelledby="headingDisbursements">
             <div class="panel-body">
               <div class="row">
                 <div class="col-sm-12">
@@ -655,14 +655,14 @@
         </div>
 
         <div class="panel panel-default">
-          <div class="panel-heading" role="tab" id="headingThree">
+          <div class="panel-heading" role="tab" id="headingForwardSpends">
             <h4 class="panel-title">
-              <a class="collapsed" role="button" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+              <a class="collapsed" role="button" data-toggle="collapse" href="#collapseForwardSpends" aria-expanded="false" aria-controls="collapseForwardSpends">
                 {{ _('Forward spending plans') }}
               </a>
             </h4>
           </div>
-          <div id="collapseThree" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
+          <div id="collapseForwardSpends" class="panel-collapse collapse in forwardspends-data" role="tabpanel" aria-labelledby="headingForwardSpends">
             <div class="panel-body">
               <div class="row">
                 <div class="col-sm-12">

--- a/maediprojects/templates/export.html
+++ b/maediprojects/templates/export.html
@@ -12,82 +12,131 @@
 <p><a class="btn btn-sm btn-default" href="{{url_for('all_activities_xlsx')}}"><span class="glyphicon glyphicon-download-alt"></span> {{ _('Download Excel') }}</a></p>
 <hr />
 <h1>{{ _('Excel reporting templates') }}</h1>
-<p class="lead">You can import data that donors have entered on the
-  AMCU quarterly reporting template. This means you do not have to go through
-  each project and manually update it: you can upload one file for each donor.</p>
-<h3><span class="glyphicon glyphicon-download"></span> Download donor quarterly reporting templates</h3>
-<p class="lead">Generate quarterly reporting templates for <i>{{ previous_fy_fq }}</i> for one or all donors. You should 
-  then send the template to the relevant donor via email, as an Excel attachment.</p>
-<div class="btn-group">
-  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Select template to download  <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-    <li>
-      <a href="{{ url_for('export_donor_template')}}">
-        Download templates for all donors
-      </a>
-    </li>
-    <li role="separator" class="divider"></li>
-    {% for org in funding_orgs %}
-    <li><a href="{{ url_for('export_donor_template', organisation_id=org.id) }}">
-      Template for {{ org.name }}
-    </a></li>
-    {% endfor %}
-  </ul>
-</div>
-<h3><span class="glyphicon glyphicon-download"></span> Download donor MTEF forward projections reporting templates</h3>
-<p class="lead">Generate annual forward projections reporting templates for one or all donors. You should 
-  then send the template to the relevant donor via email, as an Excel attachment.</p>
-<div class="btn-group">
-  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Select template to download  <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-    <li>
-      <a href="{{ url_for('export_donor_template', mtef=True)}}">
-        Download templates for all donors
-      </a>
-    </li>
-    <li role="separator" class="divider"></li>
-    {% for org in funding_orgs %}
-    <li><a href="{{ url_for('export_donor_template', mtef=True, organisation_id=org.id) }}">
-      Template for {{ org.name }}
-    </a></li>
-    {% endfor %}
-  </ul>
-</div>
-<h3><span class="glyphicon glyphicon-upload"></span> Import data from quarterly reporting template</h3>
-<p class="lead">Import Excel files following the donor quarterly reporting 
-  template format.</p>
-<form class="form-horizontal" method="post" enctype="multipart/form-data" action="{{ url_for('import_template')}}">
-  <div class="form-group">
-    <label for="file" class="col-sm-2 control-label">Template file</label>
-    <div class="col-sm-10">
-      <input type="file" id="file" name="file">
-      <p class="help-block">Select an Excel file to import. The file must
-        be formatted according to the donor quarterly reporting template.</p>
+<p class="lead">You can import data that donors have entered on
+  AMCU reporting templates. This means you do not have to go through
+  each project and manually update it: the templates are automatically
+  generated and then you can import one file for each donor.</p>
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingDisb">
+      <h4 class="panel-title">
+        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDisb" aria-expanded="true" aria-controls="collapseDisb">
+          Quarterly disbursement reporting
+        </a>
+      </h4>
+    </div>
+    <div id="collapseDisb" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingDisb">
+      <div class="panel-body">
+        <h3><span class="glyphicon glyphicon-download"></span> Download templates</h3>
+        <p class="lead">Generate quarterly reporting templates for <i>{{ previous_fy_fq }}</i> for one or all donors. You should 
+          then send the template to the relevant donor via email, as an Excel attachment.</p>
+        <div class="btn-group">
+          <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Select template to download  <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li>
+              <a href="{{ url_for('export_donor_template')}}">
+                Download templates for all donors
+              </a>
+            </li>
+            <li role="separator" class="divider"></li>
+            {% for org in funding_orgs %}
+            <li><a href="{{ url_for('export_donor_template', organisation_id=org.id) }}">
+              Template for {{ org.name }}
+            </a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        <hr />
+        <h3><span class="glyphicon glyphicon-upload"></span> Import data from template</h3>
+        <p class="lead">Import Excel files following the donor quarterly reporting 
+          template format.</p>
+        <form class="form-horizontal" method="post" enctype="multipart/form-data" action="{{ url_for('import_template')}}">
+          <div class="form-group">
+            <label for="file" class="col-sm-2 control-label">Template file</label>
+            <div class="col-sm-10">
+              <input type="file" id="file" name="file">
+              <p class="help-block">Select an Excel file to import. The file must
+                be formatted according to the donor quarterly reporting template.</p>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="file" class="col-sm-2 control-label">FY/FQ data to import</label>
+            <div class="col-sm-10">
+              <select class="select form-control" name="fy_fq">
+                {% for fy_fq in available_fys_fqs %}
+                <option value="{{ fy_fq.value }}"{{ fy_fq.selected }}>{{ fy_fq.text }}</option>
+                {% endfor %}
+              </select>
+              <p class="help-block">Select which fiscal year/quarter you would like to import.
+              Note that only data from this column will be imported.</p>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+              <button type="submit" class="btn btn-primary">
+              <span class="glyphicon glyphicon-open"></span> Import data from template</button>
+            </div>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-  <div class="form-group">
-    <label for="file" class="col-sm-2 control-label">FY/FQ data to import</label>
-    <div class="col-sm-10">
-      <select class="select form-control" name="fy_fq">
-        {% for fy_fq in available_fys_fqs %}
-        <option value="{{ fy_fq.value }}"{{ fy_fq.selected }}>{{ fy_fq.text }}</option>
-        {% endfor %}
-      </select>
-      <p class="help-block">Select which fiscal year/quarter you would like to import.
-      Note that only data from this column will be imported.</p>
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingMTEF">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMTEF" aria-expanded="false" aria-controls="collapseMTEF">
+          MTEF projections reporting
+        </a>
+      </h4>
+    </div>
+    <div id="collapseMTEF" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="collapseMTEF">
+      <div class="panel-body">
+        <h3><span class="glyphicon glyphicon-download"></span> Download templates</h3>
+        <p class="lead">Generate annual forward projections reporting templates for one or all donors. You should 
+          then send the template to the relevant donor via email, as an Excel attachment.</p>
+        <div class="btn-group">
+          <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Select template to download  <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li>
+              <a href="{{ url_for('export_donor_template', mtef=True)}}">
+                Download templates for all donors
+              </a>
+            </li>
+            <li role="separator" class="divider"></li>
+            {% for org in funding_orgs %}
+            <li><a href="{{ url_for('export_donor_template', mtef=True, organisation_id=org.id) }}">
+              Template for {{ org.name }}
+            </a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        <hr />
+        <h3><span class="glyphicon glyphicon-upload"></span> Import data from templates</h3>
+        <p class="lead">Import Excel files following the donor MTEF / forward projections reporting
+          template format.</p>
+        <form class="form-horizontal" method="post" enctype="multipart/form-data" action="{{ url_for('import_template', mtef=True)}}">
+          <div class="form-group">
+            <label for="file" class="col-sm-2 control-label">Template file</label>
+            <div class="col-sm-10">
+              <input type="file" id="file" name="file">
+              <p class="help-block">Select an Excel file to import. The file must
+                be formatted according to the MTEF reporting template.</p>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+              <button type="submit" class="btn btn-primary">
+              <span class="glyphicon glyphicon-open"></span> Import data from template</button>
+            </div>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <button type="submit" class="btn btn-primary">
-      <span class="glyphicon glyphicon-open"></span> Import data from template</button>
-    </div>
-  </div>
-</form>
 <hr />
 <h1>{{ _('Other formats') }}</h1>
 <dl class="dl-horizontal">

--- a/maediprojects/templates/export.html
+++ b/maediprojects/templates/export.html
@@ -36,6 +36,27 @@
     {% endfor %}
   </ul>
 </div>
+<h3><span class="glyphicon glyphicon-download"></span> Download donor MTEF forward projections reporting templates</h3>
+<p class="lead">Generate annual forward projections reporting templates for one or all donors. You should 
+  then send the template to the relevant donor via email, as an Excel attachment.</p>
+<div class="btn-group">
+  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Select template to download  <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu">
+    <li>
+      <a href="{{ url_for('export_donor_template', mtef=True)}}">
+        Download templates for all donors
+      </a>
+    </li>
+    <li role="separator" class="divider"></li>
+    {% for org in funding_orgs %}
+    <li><a href="{{ url_for('export_donor_template', mtef=True, organisation_id=org.id) }}">
+      Template for {{ org.name }}
+    </a></li>
+    {% endfor %}
+  </ul>
+</div>
 <h3><span class="glyphicon glyphicon-upload"></span> Import data from quarterly reporting template</h3>
 <p class="lead">Import Excel files following the donor quarterly reporting 
   template format.</p>

--- a/maediprojects/views/activities.py
+++ b/maediprojects/views/activities.py
@@ -93,19 +93,28 @@ def import_template():
         flash('Please select a file.', "warning")
         return redirect(request.url)
     if file and allowed_file(file.filename):
-        fy_fq = request.form['fy_fq']
-        # For each sheet: convert to dict
-        # For each line in each sheet:
-        # Process (financial data) import column
-        # If no data in that FQ: then import
-        # If there was data for that FY: then don't import
-        result = qgenerate_xlsx.import_xls(file, fy_fq)
-        if result > 0: flash("{} activities successfully updated!".format(result), "success")
-        else: flash("""No activities were updated. No updated disbursements 
-        were found. Check that you selected the correct file and that it 
-        contains {} data. It must be formatted according to
-        the AMCU template format. You can download a copy of this template 
-        below.""".format(util.column_data_to_string(fy_fq)), "warning")
+        if request.args.get('mtef'):
+            result = qgenerate_xlsx.import_xls_mtef(file)
+            if result > 0: flash("{} activities successfully updated!".format(result), "success")
+            else: flash("""No activities were updated. No updated MTEF projections 
+            were found. Check that you selected the correct file and that it 
+            contains update MTEF projections data. It must be formatted according to
+            the AMCU template format. You can download a copy of this template 
+            below.""", "warning")
+        elif request.args.get('mtef') == None:
+            fy_fq = request.form['fy_fq']
+            # For each sheet: convert to dict
+            # For each line in each sheet:
+            # Process (financial data) import column
+            # If no data in that FQ: then import
+            # If there was data for that FY: then don't import
+            result = qgenerate_xlsx.import_xls(file, fy_fq)
+            if result > 0: flash("{} activities successfully updated!".format(result), "success")
+            else: flash("""No activities were updated. No updated disbursements 
+            were found. Check that you selected the correct file and that it 
+            contains {} data. It must be formatted according to
+            the AMCU template format. You can download a copy of this template 
+            below.""".format(util.column_data_to_string(fy_fq)), "warning")
         return redirect(url_for('export'))
     flash("Sorry, there was an error, and that file could not be imported", "danger")
     return redirect(url_for('export'))

--- a/maediprojects/views/api.py
+++ b/maediprojects/views/api.py
@@ -454,8 +454,13 @@ def all_activities_xlsx_filtered():
 
 @app.route("/api/export_template.xlsx")
 @app.route("/api/export_template/<organisation_id>.xlsx")
-def export_donor_template(organisation_id=None):
-    fyfq_string = util.column_data_to_string(util.previous_fy_fq())
+def export_donor_template(organisation_id=None, mtef=False):
+    if request.args.get('mtef'):
+        fyfq_string = u"MTEF Forward Projections"
+        mtef = True
+    else:
+        fyfq_string = util.column_data_to_string(util.previous_fy_fq())
+        mtef = False
     if organisation_id:
         reporting_org_name = qorganisations.get_organisation_by_id(
             organisation_id).name
@@ -471,7 +476,7 @@ def export_donor_template(organisation_id=None):
         activities = defaultdict(list)
         for a in all_activities:
             activities[a.reporting_org.name].append(a)
-    data = qgenerate_xlsx.generate_xlsx_export_template(activities)
+    data = qgenerate_xlsx.generate_xlsx_export_template(activities, mtef)
     data.seek(0)
     return send_file(data, as_attachment=True, attachment_filename=filename, 
         cache_timeout=5)


### PR DESCRIPTION
This PR includes the following:

- export MTEF projections templates, including pre-populated with summed data for each FY, and validation
- import MTEF projections, processing MTEF projections, activity status, start and end dates
- handle also activity status, start and end dates for disbursements templates
- fix a couple of places where years were hardcoded into the system (there is still some of this, however)
- fixes to a couple of small bugs

Fixes #31 and most of #30