### PR TITLE
Filter by type of implementing organisation

### DIFF
--- a/maediprojects/models.py
+++ b/maediprojects/models.py
@@ -226,10 +226,6 @@ class Activity(db.Model):
             index=True)
     recipient_country = sa.orm.relationship("Country")
     dac_sector = sa.Column(sa.UnicodeText)
-    #local_sector = sa.Column(
-    #        act_ForeignKey('codelistcode.code'),
-    #        nullable=False,
-    #        index=True)
     collaboration_type = sa.Column(sa.UnicodeText) # ADDED
     finance_type = sa.Column(sa.UnicodeText) # ADDED
     tied_status = sa.Column(sa.UnicodeText) # ADDED

--- a/maediprojects/models.py
+++ b/maediprojects/models.py
@@ -274,17 +274,17 @@ class Activity(db.Model):
         "view": (bool(current_user.permissions_dict["domestic_external"] != "none") or (op in ("view", "edit")))
         }
 
-    @hybrid_property
-    def implementing_organisations(self):
-        return Organisation.query.filter(ActivityOrganisation.activity_id==self.id,
-                                         ActivityOrganisation.role==4
-                                  ).join(ActivityOrganisation).all()
+    implementing_organisations = sa.orm.relationship("Organisation",
+        secondary="activityorganisation",
+        secondaryjoin="""and_(ActivityOrganisation.role==4,
+            ActivityOrganisation.organisation_id==Organisation.id)"""
+        )
 
-    @hybrid_property
-    def funding_organisations(self):
-        return Organisation.query.filter(ActivityOrganisation.activity_id==self.id,
-                                         ActivityOrganisation.role==1
-                                  ).join(ActivityOrganisation).all()
+    funding_organisations = sa.orm.relationship("Organisation",
+        secondary="activityorganisation",
+        secondaryjoin="""and_(ActivityOrganisation.role==1,
+            ActivityOrganisation.organisation_id==Organisation.id)"""
+        )
 
     @hybrid_property
     def total_commitments(self):

--- a/maediprojects/query/activity.py
+++ b/maediprojects/query/activity.py
@@ -226,6 +226,11 @@ def list_activities_by_filters(filters):
                 models.ActivityFinances.transaction_date < getJSONDate(filter_value))
         elif filter_name in codelist_names:
             codelist_vals.append(int(filter_value))
+        elif filter_name == 'implementing_org_type':
+            query = query.filter(
+                models.Activity.implementing_organisations.any(
+                    models.Organisation._type == filter_value)
+            )
         else:
             query = query.filter(
                 getattr(models.Activity, filter_name)==filter_value

--- a/maediprojects/query/organisations.py
+++ b/maediprojects/query/organisations.py
@@ -30,6 +30,11 @@ def get_organisation_by_name(name):
     if org: return org
     return False
 
+def get_organisation_types():
+    types = [('gol', 'Government of Liberia'),
+        ('donor', 'Donor'), ('ngo', 'NGO')]
+    return list(map(lambda t: {"id": t[0], "name": t[1]}, types))
+
 def get_reporting_orgs():
     return db.session.query(models.Organisation
         ).join(models.Activity, models.Activity.reporting_org_id==models.Organisation.id

--- a/maediprojects/views/activities.py
+++ b/maediprojects/views/activities.py
@@ -34,8 +34,8 @@ def dashboard():
 @blueprint.route("/activities/")
 @login_required
 def activities():
-    countries = qactivity.get_iati_list()
-    reporting_orgs = list(map(lambda o: {"id": o.id, "name": o.name}, qorganisations.get_reporting_orgs()))
+    reporting_orgs = qorganisations.get_reporting_orgs()
+    organisation_types = qorganisations.get_organisation_types()
     cl = codelists.get_codelists()
     _cl_domestic_external = [
         {"id": "domestic",
@@ -45,6 +45,7 @@ def activities():
     ]
     filters_codelists = [
         ("Reported by", "reporting_org_id", reporting_orgs),
+        ("Type of Implementer", "implementing_org_type", organisation_types),
         ("Sector", "mtef-sector", cl["mtef-sector"]),
         ("Aligned Ministry / Agency", "aligned-ministry-agency", cl["aligned-ministry-agency"]),
         ("PAPD Pillar", "papd-pillar", cl["papd-pillar"]),
@@ -59,11 +60,9 @@ def activities():
         "latest": latest.isoformat() if latest else None
     }
     return render_template("activities.html",
-                countries=countries,
                 reporting_orgs=reporting_orgs,
                 codelists=filters_codelists,
                 loggedinuser=current_user,
-                stats = qactivity.get_stats(current_user),
                 activity_base_url = activity_base_url,
                 dates=dates
     )


### PR DESCRIPTION
* Add a filter to allow users to choose what type of implementing organisation (government, donor, NGO) they want to search by
* Some improvements to model to use relationships rather than subqueries, allowing use of ORM here to filter by `Organisation._type`
* Removing some unnecessary calls which were significantly slowing down `/activities/`

fixes #53