### PR TITLE
Bugfix new activity / user

### DIFF
--- a/maediprojects/query/user.py
+++ b/maediprojects/query/user.py
@@ -32,6 +32,9 @@ def check_permissions(permission_name, permission_value=None):
     if permission_name in ("view", "edit"):
         if current_user.permissions_dict.get(permission_name, "none") in (permission_value, "both"):
             return True
+    if permission_name in ("new"):
+        if current_user.permissions_dict.get("edit", "none") != "none":
+            return True
     return False
 
 def check_activity_permissions(permission_name, activity_id):

--- a/maediprojects/views/activities.py
+++ b/maediprojects/views/activities.py
@@ -93,7 +93,7 @@ def activities():
 
 @blueprint.route("/activities/new/", methods=['GET', 'POST'])
 @login_required
-@quser.permissions_required("edit")
+@quser.permissions_required("new")
 def activity_new():
     if request.method == "GET":
         return render_template("activity_edit.html",

--- a/maediprojects/views/users.py
+++ b/maediprojects/views/users.py
@@ -109,7 +109,7 @@ def users_edit(user_id):
     if request.method == "GET":
         if not user:
             return abort(404)
-        return render_template("user.html",
+        return render_template("users/user.html",
                  user=user,
                  loggedinuser=current_user,
                  organisations=qorganisations.get_organisations(),


### PR DESCRIPTION
Fix bugs that do not allow users to create a new activity in all the cases they should be allowed to.

This includes a temporary workaround for permissions now; the permissions framework needs to be revisited in the near future.