### PR TITLE
Fix client connection when empty rows

### DIFF
--- a/projectdashboard/query/import_client_connection.py
+++ b/projectdashboard/query/import_client_connection.py
@@ -255,7 +255,8 @@ def load_transactions_from_file(input_file):
     data = xlsx_to_csv.getDataFromFile(
         input_file.filename, input_file.read(), 0, True, 5)
     for transaction in data:
-        if transaction['Project'] == None: break
+        if (transaction['Project'] is None or transaction['Project'].startswith('Note:')):
+            break
         try:
             add_row(input_file.filename, period_start, period_end, transaction)
         except sa.exc.IntegrityError:


### PR DESCRIPTION
Empty rows are automatically removed from parsing XLSX files now, so importer tries to process the row `Note: (FY) Fiscal year starts 1st July till 30th June of the following year` 